### PR TITLE
feat: simple model routing (code=Opus, chat=Sonnet)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,44 @@ Implementation source: `src/core/merge.ts`.
 2. Built-in preset: `src/presets/<name>/`
 3. User preset with same name overrides built-in
 
+## MODEL ROUTING
+
+The apex preset includes a `config.routing` key that enables task-type based model selection. When applied, OpenClaw uses this to route requests to different models depending on the task context.
+
+### Routing Schema
+
+```json5
+{
+  routing: {
+    defaultModel: 'provider/model-name',  // fallback for unmatched tasks
+    rules: [
+      {
+        name: 'rule-name',
+        description: 'Human-readable purpose',
+        triggers: ['trigger-1', 'trigger-2'],  // task-type keywords
+        model: 'provider/model-name',
+      },
+    ],
+  },
+}
+```
+
+### Apex Defaults
+
+| Task Type | Model | Rationale |
+|-----------|-------|-----------|
+| Coding (`tmux-opencode`, `code`, `development`, `debugging`, `refactoring`, `architecture`, `code-review`) | `anthropic/claude-opus-4-6` | Strongest reasoning for complex code tasks |
+| Everything else (conversation, simple queries) | `anthropic/claude-sonnet-4-6` | Faster, cost-efficient for routine interactions |
+
+### How It Works
+
+- Routing config lives in `config.routing` within `preset.json5` and merges into `openclaw.json` via `deepMerge`.
+- `defaultModel` is the fallback when no rule triggers match the current task type.
+- Each rule has a `triggers` array of keyword strings. If the task type matches any trigger, that rule's `model` is used.
+- Rules are evaluated in order; first match wins.
+- The `rules` array replaces entirely on merge (standard array merge semantics — no append).
+- To disable routing, set `routing: null` in a user preset override (delete semantics).
+
 ## ANTI-PATTERNS
 
 - Assuming JSON5 comments survive apply; they are dropped when config is rewritten.

--- a/src/presets/apex/preset.json5
+++ b/src/presets/apex/preset.json5
@@ -51,6 +51,28 @@
         allowBots: true,
       },
     },
+    // Model routing: select model based on task type.
+    // Coding/development tasks get the strongest model;
+    // casual conversation and simple queries use a faster, lighter model.
+    routing: {
+      defaultModel: 'anthropic/claude-sonnet-4-6',
+      rules: [
+        {
+          name: 'coding',
+          description: 'Code generation, debugging, refactoring, and development tasks',
+          triggers: [
+            'tmux-opencode',
+            'code',
+            'development',
+            'debugging',
+            'refactoring',
+            'architecture',
+            'code-review',
+          ],
+          model: 'anthropic/claude-opus-4-6',
+        },
+      ],
+    },
   },
   workspaceFiles: ['AGENTS.md', 'SOUL.md', 'USER.md', 'IDENTITY.md'],
   skills: ['prompt-guard', 'tmux-opencode', 'agent-browser'],


### PR DESCRIPTION
코딩 작업은 Opus, 일상 대화는 Sonnet으로 자동 분기하는 단순 라우팅 로직 추가.

- preset.json5에 routing 키 추가
- AGENTS.md에 라우팅 동작 방식 문서화
- biome/tsc/238 tests 전부 pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add simple model routing in the apex preset: coding tasks go to anthropic/claude-opus-4-6, all other chats use anthropic/claude-sonnet-4-6. Faster, cheaper for conversation while keeping strong reasoning for code.

- **New Features**
  - Added config.routing to preset.json5 with defaultModel and first-match rules.
  - Coding triggers (tmux-opencode, code, development, debugging, refactoring, architecture, code-review) route to Opus; everything else defaults to Sonnet.
  - Documented routing schema, behavior, and disabling (routing: null) in AGENTS.md.

<sup>Written for commit 653b19f91153d1e296af5ce9df9f905356fe1192. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

