### PR TITLE
fix(export): write preset manifest once during export

### DIFF
--- a/.changeset/fix-export-manifest.md
+++ b/.changeset/fix-export-manifest.md
@@ -1,0 +1,5 @@
+---
+"oh-my-openclaw": patch
+---
+
+Fix export command writing preset manifest twice during export

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -69,14 +69,12 @@ export async function exportCommand(
     workspaceFiles: [],
   };
 
-  // Save preset (creates dir + writes preset.json5)
-  await savePreset(presetDir, manifest);
+  await fs.mkdir(presetDir, { recursive: true });
 
   // Copy workspace MD files
   const copiedFiles = await exportWorkspaceFiles(workspaceDir, presetDir);
   manifest.workspaceFiles = copiedFiles;
 
-  // Update manifest with workspace files list
   await savePreset(presetDir, manifest);
 
   console.log(pc.green(`\n✓ Preset '${name}' exported to: ${presetDir}`));


### PR DESCRIPTION
Closes #7

## Changes
- Removed duplicate `savePreset` call in `src/commands/export.ts`
- Export now writes the manifest exactly once per invocation

## Verification
- `bun test` (256 pass), `bun run check:types` (pass), `bun run build` (pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Export now writes the preset manifest once, after copying workspace files, so the file list is correct. Removes a duplicate savePreset call that caused double writes and fixes #7.

<sup>Written for commit e34b02bc94b2f5bdd01b1cbeed776378db5c7b7d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

