### PR TITLE
fix(apply): run node path fix only on macOS

### DIFF
--- a/.changeset/fix-macos-guard.md
+++ b/.changeset/fix-macos-guard.md
@@ -1,0 +1,5 @@
+---
+"oh-my-openclaw": patch
+---
+
+Run fixNodePathIfNeeded only on macOS to avoid unnecessary path manipulation on other platforms

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -320,7 +320,9 @@ export async function applyCommand(
     }
   }
 
-  await fixNodePathIfNeeded();
+  if (process.platform === 'darwin') {
+    await fixNodePathIfNeeded();
+  }
 
   console.log(pc.green(`\nOK Preset '${preset.name}' applied.`));
   console.log(


### PR DESCRIPTION
Closes #16

## Changes
- Wrapped `fixNodePathIfNeeded()` in `if (process.platform === 'darwin')` guard in `src/commands/apply.ts`

## Verification
- `bun test` (256 pass), `bun run check:types` (pass), `bun run build` (pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run fixNodePathIfNeeded only on macOS in the apply command. This avoids unnecessary PATH changes on Linux and Windows.

<sup>Written for commit b3a6fa2528a213432c87f6e60f25cd2ab5efa53b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

