### PR TITLE
fix(remote): validate owner/repo before clone

### DIFF
--- a/.changeset/fix-validate-owner-repo.md
+++ b/.changeset/fix-validate-owner-repo.md
@@ -1,0 +1,5 @@
+---
+"oh-my-openclaw": patch
+---
+
+Validate owner/repo format before attempting git clone to provide clear error messages

--- a/src/core/__tests__/remote.test.ts
+++ b/src/core/__tests__/remote.test.ts
@@ -7,6 +7,7 @@ import { cloneToCache, isGitHubRef, parseGitHubRef } from '../remote';
 
 const tempDirs: string[] = [];
 const INVALID_GITHUB_REFERENCE_PATTERN = /Invalid GitHub reference/;
+const INVALID_GITHUB_OWNER_REPO_PATTERN = /Invalid GitHub owner\/repo/;
 const FAILED_TO_CLONE_PATTERN = /Failed to clone/;
 
 afterEach(async () => {
@@ -114,6 +115,20 @@ describe('parseGitHubRef', () => {
 });
 
 describe('cloneToCache', () => {
+  test('throws on invalid owner characters', async () => {
+    const presetsDir = await makeTempPresetsDir();
+    await expect(
+      cloneToCache('minpeter!', 'demo-researcher', presetsDir)
+    ).rejects.toThrow(INVALID_GITHUB_OWNER_REPO_PATTERN);
+  });
+
+  test('throws on invalid repo characters', async () => {
+    const presetsDir = await makeTempPresetsDir();
+    await expect(
+      cloneToCache('minpeter', 'demo-researcher;rm', presetsDir)
+    ).rejects.toThrow(INVALID_GITHUB_OWNER_REPO_PATTERN);
+  });
+
   test('clones real repo to cache directory', async () => {
     const presetsDir = await makeTempPresetsDir();
     const cachePath = await cloneToCache(

--- a/src/core/remote.ts
+++ b/src/core/remote.ts
@@ -5,6 +5,15 @@ import path from 'node:path';
 const GITHUB_OWNER_REPO_REGEX = /^[a-zA-Z0-9._-]+$/;
 const TRAILING_SLASH_PATTERN = /\/+$/;
 
+function hasValidGitHubOwnerRepo(owner: string, repo: string): boolean {
+  return (
+    owner.length > 0 &&
+    repo.length > 0 &&
+    GITHUB_OWNER_REPO_REGEX.test(owner) &&
+    GITHUB_OWNER_REPO_REGEX.test(repo)
+  );
+}
+
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => {
@@ -90,9 +99,7 @@ export function parseGitHubRef(input: string): { owner: string; repo: string } {
     throw new Error(errorMessage);
   }
 
-  if (
-    !(GITHUB_OWNER_REPO_REGEX.test(owner) && GITHUB_OWNER_REPO_REGEX.test(repo))
-  ) {
+  if (!hasValidGitHubOwnerRepo(owner, repo)) {
     throw new Error(errorMessage);
   }
 
@@ -105,6 +112,12 @@ export async function cloneToCache(
   presetsDir: string,
   options?: { force?: boolean }
 ): Promise<string> {
+  if (!hasValidGitHubOwnerRepo(owner, repo)) {
+    throw new Error(
+      `Invalid GitHub owner/repo: '${owner}/${repo}'. Only letters, numbers, '.', '_', and '-' are allowed.`
+    );
+  }
+
   const cachePath = path.join(presetsDir, `${owner}--${repo}`);
   const cacheExists = await fs
     .stat(cachePath)


### PR DESCRIPTION
Closes #19

## Changes
- Added owner/repo format validation in `src/core/remote.ts` before `cloneToCache` attempts git clone
- Added test cases for invalid owner/repo inputs

## Verification
- `bun test` (all pass), `bun run check:types` (pass), `bun run build` (pass)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate GitHub owner/repo format before cloning to fail fast and show a clear error message. Prevents invalid repo names from reaching git.

- **Bug Fixes**
  - Added hasValidGitHubOwnerRepo and used it in cloneToCache and parseGitHubRef.
  - Added tests for invalid owner and repo characters.

<sup>Written for commit 7200baddbc59b1575d2439aaf500b42c77d2ef9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

