### PR TITLE
fix(ci): skip npm publish when NPM_TOKEN is not set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         run: bun run build
 
       - name: Create Release Pull Request or Publish
+        if: ${{ secrets.NPM_TOKEN != '' }}
         uses: changesets/action@v1
         with:
           publish: npm publish --provenance --access public


### PR DESCRIPTION
Release 워크플로우에서 NPM_TOKEN 시크릿이 없을 때 publish 단계를 스킵하도록 수정. NPM_TOKEN이 설정되지 않은 상태에서 npm publish 시도 → ENEEDAUTH 에러로 CI 실패하던 문제 해결.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip npm publish in the release workflow when NPM_TOKEN is not set to prevent ENEEDAUTH errors and CI failures. The Changesets step now runs only if NPM_TOKEN is present.

<sup>Written for commit 2f63eb79280016e56b5c9b2e568ed4b857af1821. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

