### PR TITLE
fix(core): make resolveOpenClawPaths use async filesystem APIs

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -234,7 +234,7 @@ export async function applyCommand(
   presetName: string,
   options: ApplyOptions = {}
 ): Promise<void> {
-  const paths = resolveOpenClawPaths();
+  const paths = await resolveOpenClawPaths();
   const { preset, presetDir } = await resolvePreset(
     presetName,
     paths.presetsDir,

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -245,7 +245,7 @@ export async function uploadCommand(
   await checkGhAuth();
 
   // Resolve local paths
-  const paths = resolveOpenClawPaths();
+  const paths = await resolveOpenClawPaths();
   const currentConfig = await readCurrentConfig(paths.configPath);
   const workspaceDir = resolveWorkspaceDir(currentConfig, paths.stateDir);
 

--- a/src/core/config-path.ts
+++ b/src/core/config-path.ts
@@ -1,11 +1,24 @@
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
 import { APEX_DIR } from './constants';
 import type { ResolvedPaths } from './types';
 
-export function resolveOpenClawPaths(): ResolvedPaths {
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+export async function resolveOpenClawPaths(): Promise<ResolvedPaths> {
   let configPath: string;
   let stateDir: string;
 
@@ -22,16 +35,16 @@ export function resolveOpenClawPaths(): ResolvedPaths {
   // Migrate legacy state directory (oh-my-openclaw -> apex)
   const legacyDir = path.join(stateDir, 'oh-my-openclaw');
   const newDir = path.join(stateDir, APEX_DIR);
-  if (fs.existsSync(legacyDir) && !fs.existsSync(newDir)) {
-    fs.renameSync(legacyDir, newDir);
+  if ((await pathExists(legacyDir)) && !(await pathExists(newDir))) {
+    await fs.rename(legacyDir, newDir);
   }
 
   const workspaceDir = path.join(stateDir, 'workspace');
   const presetsDir = path.join(stateDir, APEX_DIR, 'presets');
   const backupsDir = path.join(stateDir, APEX_DIR, 'backups');
 
-  fs.mkdirSync(presetsDir, { recursive: true });
-  fs.mkdirSync(backupsDir, { recursive: true });
+  await fs.mkdir(presetsDir, { recursive: true });
+  await fs.mkdir(backupsDir, { recursive: true });
 
   return { configPath, stateDir, workspaceDir, presetsDir, backupsDir };
 }


### PR DESCRIPTION
Fixes #6

Bug: `resolveOpenClawPaths()` performs synchronous I/O at import time

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted resolveOpenClawPaths to async filesystem APIs and updated apply/upload to await it. Removes sync I/O at import time and fixes #6.

- **Bug Fixes**
  - Switched to fs/promises (access, rename, mkdir) for path checks and migrations.
  - Added a pathExists helper to safely handle ENOENT.
  - Updated applyCommand and uploadCommand to await resolveOpenClawPaths.

<sup>Written for commit 4e923e8abbcbdb00f1e9fe0f33c6785f3ae7f977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

