### PR TITLE
test(upload): remove redundant await in error assertion

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,6 +153,7 @@ program
   .description('Upload workspace files to a GitHub repo as a preset')
   .argument('<github-repo>', 'GitHub repository (e.g., owner/repo)')
   .option('--create', 'Create the repository if it does not exist')
+  .option('--force', 'Force-push to main (dangerous: rewrites history)')
   .option('--private', 'Make the repository private (used with --create)')
   .option('--description <desc>', 'Repository description (used with --create)')
   .action(
@@ -160,6 +161,7 @@ program
       githubRepo: string,
       options: {
         create?: boolean;
+        force?: boolean;
         private?: boolean;
         description?: string;
       }
@@ -167,6 +169,7 @@ program
       try {
         await uploadCommand(githubRepo, {
           create: options.create,
+          force: options.force,
           private: options.private,
           description: options.description,
         });

--- a/src/commands/__tests__/upload.test.ts
+++ b/src/commands/__tests__/upload.test.ts
@@ -293,7 +293,7 @@ describe('upload: uploadCommand error paths', () => {
 
   test('throws on invalid repo argument', async () => {
     const { uploadCommand } = await import('../upload');
-    await expect(uploadCommand('invalid-no-slash')).rejects.toThrow(
+    return expect(uploadCommand('invalid-no-slash')).rejects.toThrow(
       'Invalid GitHub repository'
     );
   });

--- a/src/commands/__tests__/upload.test.ts
+++ b/src/commands/__tests__/upload.test.ts
@@ -3,7 +3,12 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { buildManifest, parseRepo, prepareStagingDir } from '../upload';
+import {
+  buildManifest,
+  buildPushCommand,
+  parseRepo,
+  prepareStagingDir,
+} from '../upload';
 
 describe('upload: parseRepo', () => {
   test('parses owner/repo shorthand', () => {
@@ -81,6 +86,23 @@ describe('upload: buildManifest', () => {
     expect(manifest.name).toBe('empty');
     expect(manifest.config).toEqual({});
     expect(manifest.workspaceFiles).toEqual([]);
+  });
+});
+
+describe('upload: buildPushCommand', () => {
+  test('uses normal push by default', () => {
+    expect(buildPushCommand()).toEqual(['git', 'push', '-u', 'origin', 'main']);
+  });
+
+  test('adds force flag only when explicitly enabled', () => {
+    expect(buildPushCommand(true)).toEqual([
+      'git',
+      'push',
+      '-u',
+      'origin',
+      'main',
+      '--force',
+    ]);
   });
 });
 

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -17,6 +17,7 @@ import { listWorkspaceFiles, resolveWorkspaceDir } from '../core/workspace';
 interface UploadOptions {
   create?: boolean;
   description?: string;
+  force?: boolean;
   private?: boolean;
 }
 
@@ -193,7 +194,8 @@ export async function prepareStagingDir(
 async function pushToGitHub(
   stagingDir: string,
   owner: string,
-  repo: string
+  repo: string,
+  force?: boolean
 ): Promise<void> {
   const cwd = stagingDir;
 
@@ -227,11 +229,17 @@ async function pushToGitHub(
     { cwd }
   );
 
-  await execOrThrow(
-    ['git', 'push', '-u', 'origin', 'main', '--force'],
-    'Failed to push to GitHub',
-    { cwd }
-  );
+  await execOrThrow(buildPushCommand(force), 'Failed to push to GitHub', {
+    cwd,
+  });
+}
+
+export function buildPushCommand(force?: boolean): string[] {
+  const command = ['git', 'push', '-u', 'origin', 'main'];
+  if (force) {
+    command.push('--force');
+  }
+  return command;
 }
 
 export async function uploadCommand(
@@ -302,7 +310,7 @@ export async function uploadCommand(
 
   try {
     // Push to GitHub
-    await pushToGitHub(stagingDir, owner, repo);
+    await pushToGitHub(stagingDir, owner, repo, options.force);
   } finally {
     // Cleanup staging directory
     await fs.rm(stagingDir, { recursive: true, force: true }).catch(() => {


### PR DESCRIPTION
Fixes #11

Bug: `upload` command force-pushes to main, destroys existing repo history

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make upload safe by default: it no longer force-pushes to main, preventing repo history loss. Added a --force flag for explicit overrides and updated tests.

- **Bug Fixes**
  - Default push no longer uses --force; history is preserved (fixes #11).

- **New Features**
  - Adds --force CLI flag and a buildPushCommand helper to apply force only when explicitly enabled.

<sup>Written for commit 03eb2f02b0a441f65edb0a04cd8e49868e52bf1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

