### PR TITLE
fix(core): support ** wildcard matching in sensitive filter

### DIFF
--- a/src/core/__tests__/sensitive-filter.test.ts
+++ b/src/core/__tests__/sensitive-filter.test.ts
@@ -149,12 +149,31 @@ describe('filterSensitiveFields', () => {
       expect(isSensitivePath(['hooks', 'token'])).toBe(true);
     });
 
-    test('matches models.providers.*.apiKey with any provider name', () => {
+    test('matches models.providers.**.apiKey across nested provider paths', () => {
       expect(isSensitivePath(['models', 'providers', 'openai', 'apiKey'])).toBe(
         true
       );
       expect(
         isSensitivePath(['models', 'providers', 'anthropic', 'apiKey'])
+      ).toBe(true);
+      expect(
+        isSensitivePath([
+          'models',
+          'providers',
+          'anthropic',
+          'settings',
+          'apiKey',
+        ])
+      ).toBe(true);
+      expect(
+        isSensitivePath([
+          'models',
+          'providers',
+          'anthropic',
+          'region',
+          'seoul',
+          'apiKey',
+        ])
       ).toBe(true);
       expect(isSensitivePath(['models', 'providers', 'custom', 'apiKey'])).toBe(
         true
@@ -177,6 +196,15 @@ describe('filterSensitiveFields', () => {
       expect(isSensitivePath(['gateway', 'port'])).toBe(false);
       expect(
         isSensitivePath(['models', 'providers', 'openai', 'baseUrl'])
+      ).toBe(false);
+      expect(
+        isSensitivePath([
+          'models',
+          'providers',
+          'anthropic',
+          'settings',
+          'baseUrl',
+        ])
       ).toBe(false);
     });
 

--- a/src/core/__tests__/types.test.ts
+++ b/src/core/__tests__/types.test.ts
@@ -20,7 +20,7 @@ describe('core constants', () => {
       'meta',
       'gateway.auth',
       'hooks.token',
-      'models.providers.*.apiKey',
+      'models.providers.**.apiKey',
       'channels.*.botToken',
       'channels.*.token',
     ];

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -7,7 +7,7 @@ export const SENSITIVE_FIELDS = [
   'meta',
   'gateway.auth',
   'hooks.token',
-  'models.providers.*.apiKey',
+  'models.providers.**.apiKey',
   'channels.*.botToken',
   'channels.*.token',
 ] as const;

--- a/src/core/sensitive-filter.ts
+++ b/src/core/sensitive-filter.ts
@@ -15,24 +15,48 @@ const SECRET_VALUE_PATTERNS = [
 
 function matchesPattern(path: string[], pattern: string): boolean {
   const patternParts = pattern.split('.');
+  const memo = new Map<string, boolean>();
 
-  if (path.length !== patternParts.length) {
+  function match(pathIndex: number, patternIndex: number): boolean {
+    const key = `${pathIndex}:${patternIndex}`;
+    const cached = memo.get(key);
+
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    if (patternIndex === patternParts.length) {
+      const isMatch = pathIndex === path.length;
+      memo.set(key, isMatch);
+      return isMatch;
+    }
+
+    const patternPart = patternParts[patternIndex];
+
+    if (patternPart === '**') {
+      const isMatch =
+        match(pathIndex, patternIndex + 1) ||
+        (pathIndex < path.length && match(pathIndex + 1, patternIndex));
+      memo.set(key, isMatch);
+      return isMatch;
+    }
+
+    if (pathIndex >= path.length) {
+      memo.set(key, false);
+      return false;
+    }
+
+    if (patternPart === '*' || path[pathIndex] === patternPart) {
+      const isMatch = match(pathIndex + 1, patternIndex + 1);
+      memo.set(key, isMatch);
+      return isMatch;
+    }
+
+    memo.set(key, false);
     return false;
   }
 
-  for (let index = 0; index < patternParts.length; index += 1) {
-    const patternPart = patternParts[index];
-
-    if (patternPart === '*') {
-      continue;
-    }
-
-    if (path[index] !== patternPart) {
-      return false;
-    }
-  }
-
-  return true;
+  return match(0, 0);
 }
 
 function cloneValue(value: unknown): unknown {


### PR DESCRIPTION
Fixes #21

Bug: `sensitive-filter.ts` wildcard matching only supports single-level wildcards — nested sensitive fields leak

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-level wildcard support in the sensitive filter to prevent nested secrets from leaking. Paths like models.providers.<name>.settings.apiKey are now correctly masked.

- **Bug Fixes**
  - Added support for the ** wildcard in path matching using memoized recursion.
  - Updated SENSITIVE_FIELDS to models.providers.**.apiKey to catch nested provider secrets.
  - Extended tests to cover deep paths and ensure non-secret fields (e.g., baseUrl) remain visible.

<sup>Written for commit 3081bdcdaf4839cc0c1f04f8ff4222f9b3fca1a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

