### PR TITLE
fix(upload): wait for git process close before staging cleanup

### DIFF
--- a/src/commands/__tests__/upload.test.ts
+++ b/src/commands/__tests__/upload.test.ts
@@ -276,3 +276,107 @@ describe('upload: uploadCommand error paths', () => {
     );
   });
 });
+
+describe('upload: uploadCommand staging cleanup', () => {
+  let tempStateDir: string;
+  let tempBinDir: string;
+  let markerPath: string;
+  let originalPath: string;
+
+  beforeEach(async () => {
+    tempStateDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'upload-cleanup-test-')
+    );
+    tempBinDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'upload-cleanup-bin-')
+    );
+    markerPath = path.join(tempStateDir, 'staging-dir.txt');
+    originalPath = process.env.PATH ?? '';
+
+    const ghPath = path.join(tempBinDir, 'gh');
+    const gitPath = path.join(tempBinDir, 'git');
+
+    await fs.writeFile(
+      ghPath,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "gh version 0.0.0"
+  exit 0
+fi
+
+if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
+  exit 0
+fi
+
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  echo '{"name":"repo"}'
+  exit 0
+fi
+
+echo "unexpected gh command: $*" >&2
+exit 1
+`,
+      'utf-8'
+    );
+
+    await fs.writeFile(
+      gitPath,
+      `#!/bin/sh
+if [ "$1" = "init" ]; then
+  mkdir -p .git
+  exit 0
+fi
+
+if [ "$1" = "add" ] || [ "$1" = "commit" ] || [ "$1" = "branch" ] || [ "$1" = "remote" ]; then
+  exit 0
+fi
+
+if [ "$1" = "push" ]; then
+  mkdir -p cleanup-gate
+  chmod 000 cleanup-gate
+  sleep 0.2
+  chmod 755 cleanup-gate
+  printf "%s" "$PWD" > "$APEX_UPLOAD_TEST_STAGING_PATH"
+  exit 0
+fi
+
+echo "unexpected git command: $*" >&2
+exit 1
+`,
+      'utf-8'
+    );
+
+    await fs.chmod(ghPath, 0o755);
+    await fs.chmod(gitPath, 0o755);
+
+    process.env.OPENCLAW_STATE_DIR = tempStateDir;
+    Reflect.deleteProperty(process.env, 'OPENCLAW_CONFIG_PATH');
+    process.env.APEX_UPLOAD_TEST_STAGING_PATH = markerPath;
+    process.env.PATH = `${tempBinDir}:${originalPath}`;
+  });
+
+  afterEach(async () => {
+    Reflect.deleteProperty(process.env, 'OPENCLAW_STATE_DIR');
+    Reflect.deleteProperty(process.env, 'OPENCLAW_CONFIG_PATH');
+    Reflect.deleteProperty(process.env, 'APEX_UPLOAD_TEST_STAGING_PATH');
+    process.env.PATH = originalPath;
+
+    if (tempBinDir) {
+      await fs.rm(tempBinDir, { recursive: true, force: true });
+    }
+
+    if (tempStateDir) {
+      await fs.rm(tempStateDir, { recursive: true, force: true });
+    }
+  });
+
+  test('waits for git push completion before staging cleanup', async () => {
+    const { uploadCommand } = await import('../upload');
+
+    await uploadCommand('owner/repo');
+
+    const stagingDir = (await fs.readFile(markerPath, 'utf-8')).trim();
+    expect(stagingDir.length).toBeGreaterThan(0);
+    await expect(fs.stat(stagingDir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -49,15 +50,40 @@ export function parseRepo(input: string): { owner: string; repo: string } {
 async function exec(
   command: string[],
   options?: { cwd?: string }
-): Promise<{ stdout: string; exitCode: number }> {
-  const proc = Bun.spawn(command, {
-    cwd: options?.cwd,
-    stdout: 'pipe',
-    stderr: 'pipe',
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const [file, ...args] = command;
+  if (!file) {
+    throw new Error('Command must not be empty');
+  }
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(file, args, {
+      cwd: options?.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({
+        stdout: stdout.trim(),
+        stderr: stderr.trim(),
+        exitCode: code ?? 1,
+      });
+    });
   });
-  const stdout = await new Response(proc.stdout).text();
-  const exitCode = await proc.exited;
-  return { stdout: stdout.trim(), exitCode };
 }
 
 async function execOrThrow(
@@ -65,21 +91,14 @@ async function execOrThrow(
   errorMessage: string,
   options?: { cwd?: string }
 ): Promise<string> {
-  const proc = Bun.spawn(command, {
-    cwd: options?.cwd,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  const stdout = await new Response(proc.stdout).text();
-  const stderr = await new Response(proc.stderr).text();
-  const exitCode = await proc.exited;
+  const { stdout, stderr, exitCode } = await exec(command, options);
 
   if (exitCode !== 0) {
-    const detail = stderr.trim() || stdout.trim();
+    const detail = stderr || stdout;
     throw new Error(`${errorMessage}${detail ? `: ${detail}` : ''}`);
   }
 
-  return stdout.trim();
+  return stdout;
 }
 
 async function checkGhInstalled(): Promise<void> {


### PR DESCRIPTION
Fixes #22

Bug: `upload` command staging directory cleanup race — `finally` block runs before `pushToGitHub` git processes terminate

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in upload cleanup by waiting for git processes to fully close before removing the staging directory. Prevents intermittent cleanup errors during git push.

- **Bug Fixes**
  - Replace Bun.spawn with node:child_process spawn and wait for the child process close event.
  - Update exec to return stdout, stderr, and exitCode; improve execOrThrow error messages.
  - Add test to ensure staging cleanup happens only after git push completes.

<sup>Written for commit 06759d67f04d98cda2095631647897cb80aea4e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

