### PR TITLE
fix: remove NPM_TOKEN gate from release workflow (using OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
         run: bun run build
 
       - name: Create Release Pull Request or Publish
-        if: ${{ secrets.NPM_TOKEN != '' }}
         uses: changesets/action@v1
         with:
           publish: npm publish --provenance --access public
@@ -58,5 +57,4 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Release workflow had `if: secrets.NPM_TOKEN != ''` condition which skips publish when no NPM_TOKEN is set. Since we use OIDC Trusted Publisher, NPM_TOKEN is not needed. Also removed NODE_AUTH_TOKEN reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use OIDC Trusted Publisher in the release workflow by removing the NPM_TOKEN gate and NODE_AUTH_TOKEN env. Publishing no longer depends on a secret and won’t be skipped; npm provenance remains enabled.

<sup>Written for commit 01079fb1b25e2b3cee2ec9e3b32e4d956474c3d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

