### PR TITLE
fix(apply): preserve user model settings during preset merge

### DIFF
--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -6,7 +6,7 @@ import pc from 'picocolors';
 
 import { createBackup, createWorkspaceBackup } from '../core/backup';
 import { resolveOpenClawPaths } from '../core/config-path';
-import { WORKSPACE_FILES } from '../core/constants';
+import { PRESERVE_IF_SET_FIELDS, WORKSPACE_FILES } from '../core/constants';
 import { fixNodePathIfNeeded } from '../core/fix-node-path';
 import {
   isFileNotFoundError,
@@ -197,12 +197,65 @@ async function removeWorkspaceFiles(workspaceDir: string): Promise<void> {
   }
 }
 
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== 'object'
+    ) {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+function setNestedValue(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown
+): void {
+  const parts = path.split('.');
+  let current: Record<string, unknown> = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const part = parts[i];
+    if (
+      !(part in current) ||
+      typeof current[part] !== 'object' ||
+      current[part] === null
+    ) {
+      current[part] = {};
+    }
+    current = current[part] as Record<string, unknown>;
+  }
+  const lastPart = parts.at(-1);
+  if (lastPart !== undefined) {
+    current[lastPart] = value;
+  }
+}
+
 function buildMergedConfig(
   currentConfig: Record<string, unknown>,
   preset: PresetManifest
-): { applied: string[]; mergedConfig: Record<string, unknown> } {
+): {
+  applied: string[];
+  mergedConfig: Record<string, unknown>;
+  preserved: string[];
+} {
   if (!hasPresetConfig(preset)) {
-    return { applied: [], mergedConfig: currentConfig };
+    return { applied: [], mergedConfig: currentConfig, preserved: [] };
+  }
+
+  // Save user-set values that should not be overwritten
+  const savedValues = new Map<string, unknown>();
+  for (const field of PRESERVE_IF_SET_FIELDS) {
+    const existing = getNestedValue(currentConfig, field);
+    if (existing !== undefined) {
+      savedValues.set(field, existing);
+    }
   }
 
   const filteredPresetConfig = filterSensitiveFields(
@@ -210,7 +263,18 @@ function buildMergedConfig(
   );
   const rawMerged = deepMerge(currentConfig, filteredPresetConfig);
   const { config: mergedConfig, applied } = migrateLegacyKeys(rawMerged);
-  return { applied, mergedConfig };
+
+  // Restore preserved values
+  const preserved: string[] = [];
+  for (const [field, value] of savedValues) {
+    const newValue = getNestedValue(mergedConfig, field);
+    if (newValue !== value) {
+      setNestedValue(mergedConfig, field, value);
+      preserved.push(field);
+    }
+  }
+
+  return { applied, mergedConfig, preserved };
 }
 
 function printDryRunInfo(preset: PresetManifest): void {
@@ -262,9 +326,17 @@ export async function applyCommand(
     );
   }
 
-  const { applied, mergedConfig } = buildMergedConfig(currentConfig, preset);
+  const { applied, mergedConfig, preserved } = buildMergedConfig(
+    currentConfig,
+    preset
+  );
   if (applied.length > 0) {
     console.log(pc.dim(`Legacy key migration: ${applied.join(', ')}`));
+  }
+  if (preserved.length > 0) {
+    console.log(
+      pc.dim(`Preserved existing user settings: ${preserved.join(', ')}`)
+    );
   }
 
   if (options.dryRun) {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -12,6 +12,17 @@ export const SENSITIVE_FIELDS = [
   'channels.*.token',
 ] as const;
 
+/**
+ * Config paths that should not be overwritten by preset apply
+ * when the user has already set them. This prevents silent model
+ * drift when applying a preset to an existing configuration.
+ */
+export const PRESERVE_IF_SET_FIELDS = [
+  'agents.defaults.model.primary',
+  'agents.defaults.model.secondary',
+  'agents.defaults.model.fast',
+] as const;
+
 export const WORKSPACE_FILES = [
   'AGENTS.md',
   'SOUL.md',


### PR DESCRIPTION
Fixes #38

apply/install 시 사용자가 이미 설정한 모델(agents.defaults.model.primary 등)이 preset 값으로 덮어써지던 문제 수정. 기존 설정이 있으면 보존하고, 보존된 필드를 로그로 표시.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves existing user model settings during preset apply/install so they aren’t overwritten. Shows a log of which fields were kept. Fixes #38.

- **Bug Fixes**
  - Added logic to save and restore nested values for agents.defaults.model.primary/secondary/fast during merge.
  - Introduced PRESERVE_IF_SET_FIELDS to centralize protected config paths.
  - Logs preserved fields to make changes visible during apply/install and dry runs.

<sup>Written for commit e5d62d9e1440e5d4633b26a04e105fba46948b68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

