### PR TITLE
fix: improve JSON5 comment loss warning on apply

### DIFF
--- a/src/commands/__tests__/apply.test.ts
+++ b/src/commands/__tests__/apply.test.ts
@@ -231,10 +231,12 @@ describe('applyCommand', () => {
   test('--dry-run shows changes without writing', async () => {
     const env = await createTempEnv('openclaw-apply-dry-run-');
 
-    const originalConfig = {
-      identity: { name: 'DryRunOriginal' },
-    };
-    await writeConfig(env.configPath, originalConfig);
+    const originalConfig = { identity: { name: 'DryRunOriginal' } };
+    await fs.writeFile(
+      env.configPath,
+      "{\n  // keep this comment\n  identity: { name: 'DryRunOriginal' },\n}\n",
+      'utf-8'
+    );
 
     await writeUserPreset(env.presetsDir, 'dry-run-preset', {
       name: 'dry-run-preset',
@@ -262,6 +264,35 @@ describe('applyCommand', () => {
     const combined = logs.join('\n');
     expect(combined).toContain('DRY RUN');
     expect(combined).toContain('dry-run-preset');
+    expect(combined).toContain('Dry-run note: detected JSON5 comments');
+    expect(combined).toContain('remove those comments');
+  });
+
+  test('warns when apply rewrites existing JSON5 comments', async () => {
+    const env = await createTempEnv('openclaw-apply-comment-warning-');
+
+    await fs.writeFile(
+      env.configPath,
+      "{\n  // comment to preserve manually\n  identity: { name: 'Before' },\n}\n",
+      'utf-8'
+    );
+
+    await writeUserPreset(env.presetsDir, 'comment-warning-preset', {
+      name: 'comment-warning-preset',
+      description: 'Comment warning preset',
+      version: '1.0.0',
+      config: {
+        identity: { name: 'After' },
+      },
+    });
+
+    const logs = await captureLogs(async () => {
+      await applyCommand('comment-warning-preset', { noBackup: true });
+    });
+
+    const combined = logs.join('\n');
+    expect(combined).toContain('Warning: detected JSON5 comments');
+    expect(combined).toContain('removes those comments');
   });
 
   test('filters sensitive fields from preset config before merge', async () => {

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -9,6 +9,7 @@ import { resolveOpenClawPaths } from '../core/config-path';
 import { PRESERVE_IF_SET_FIELDS, WORKSPACE_FILES } from '../core/constants';
 import { fixNodePathIfNeeded } from '../core/fix-node-path';
 import {
+  hasJson5Comments,
   isFileNotFoundError,
   readJson5,
   writeJson5,
@@ -102,12 +103,14 @@ async function resolvePreset(
 async function loadCurrentConfig(configPath: string): Promise<{
   config: Record<string, unknown>;
   exists: boolean;
+  hasJson5Comments: boolean;
 }> {
   try {
     const snapshot = await readJson5(configPath);
     return {
       config: snapshot.parsed,
       exists: true,
+      hasJson5Comments: hasJson5Comments(snapshot.raw),
     };
   } catch (error) {
     if (!isFileNotFoundError(error)) {
@@ -117,6 +120,7 @@ async function loadCurrentConfig(configPath: string): Promise<{
     return {
       config: {},
       exists: false,
+      hasJson5Comments: false,
     };
   }
 }
@@ -277,13 +281,57 @@ function buildMergedConfig(
   return { applied, mergedConfig, preserved };
 }
 
-function printDryRunInfo(preset: PresetManifest): void {
+function buildJson5CommentLossMessage(
+  configPath: string,
+  hasExistingJson5Comments: boolean,
+  dryRun: boolean
+): string {
+  if (dryRun) {
+    if (hasExistingJson5Comments) {
+      return `Dry-run note: detected JSON5 comments in ${configPath}. Applying this preset will rewrite the file as standard JSON and remove those comments.`;
+    }
+
+    return `Dry-run note: applying this preset rewrites ${configPath} as standard JSON. JSON5 comments are not preserved.`;
+  }
+
+  if (hasExistingJson5Comments) {
+    return `Warning: detected JSON5 comments in ${configPath}. Applying this preset rewrites the file as standard JSON and removes those comments.`;
+  }
+
+  return `Warning: applying this preset rewrites ${configPath} as standard JSON. JSON5 comments are not preserved.`;
+}
+
+function printDryRunInfo(
+  preset: PresetManifest,
+  options: {
+    configExists: boolean;
+    configHasJson5Comments: boolean;
+    configPath: string;
+  }
+): void {
   console.log(pc.bold(pc.yellow('DRY RUN - no files will be modified\n')));
   console.log(`Preset: ${pc.bold(preset.name)} (${preset.description})`);
   if (hasPresetConfig(preset)) {
     console.log(
       `Config changes: ${Object.keys(preset.config as Record<string, unknown>).length} top-level keys`
     );
+    if (options.configExists) {
+      console.log(
+        pc.yellow(
+          buildJson5CommentLossMessage(
+            options.configPath,
+            options.configHasJson5Comments,
+            true
+          )
+        )
+      );
+    } else {
+      console.log(
+        pc.yellow(
+          `Dry-run note: ${options.configPath} does not exist. Applying this preset will create it as standard JSON.`
+        )
+      );
+    }
   }
   if (preset.workspaceFiles?.length) {
     console.log(`Workspace files: ${preset.workspaceFiles.join(', ')}`);
@@ -308,6 +356,7 @@ export async function applyCommand(
   const configSnapshot = await loadCurrentConfig(paths.configPath);
   let currentConfig = configSnapshot.config;
   let configExists = configSnapshot.exists;
+  const configHasJson5Comments = configSnapshot.hasJson5Comments;
   const workspaceDir = resolveWorkspaceDir(currentConfig, paths.stateDir);
 
   if (options.clean && !options.dryRun) {
@@ -343,7 +392,11 @@ export async function applyCommand(
     if (options.clean) {
       console.log(pc.yellow('Mode: CLEAN INSTALL'));
     }
-    printDryRunInfo(preset);
+    printDryRunInfo(preset, {
+      configExists,
+      configHasJson5Comments,
+      configPath: paths.configPath,
+    });
     return;
   }
 
@@ -362,7 +415,11 @@ export async function applyCommand(
     if (configExists) {
       console.log(
         pc.yellow(
-          'Warning: JSON5 comments in your config will be lost (known MVP limitation).'
+          buildJson5CommentLossMessage(
+            paths.configPath,
+            configHasJson5Comments,
+            false
+          )
         )
       );
     } else {

--- a/src/core/__tests__/json5-utils.test.ts
+++ b/src/core/__tests__/json5-utils.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import {
+  hasJson5Comments,
   isFileNotFoundError,
   parseJson5,
   readJson5,
@@ -103,6 +104,32 @@ describe('json5-utils', () => {
     const stringified = stringifyJson5(data);
 
     expect(parseJson5(stringified)).toEqual(data);
+  });
+
+  describe('hasJson5Comments', () => {
+    test('returns true for line comments', () => {
+      expect(hasJson5Comments('{\n  // comment\n  name: "test"\n}')).toBe(
+        true
+      );
+    });
+
+    test('returns true for block comments', () => {
+      expect(
+        hasJson5Comments('{\n  /* block comment */\n  name: "test"\n}')
+      ).toBe(true);
+    });
+
+    test('ignores comment-like content inside strings', () => {
+      expect(
+        hasJson5Comments(
+          '{\n  url: "https://example.com",\n  pattern: "/*not-comment*/"\n}'
+        )
+      ).toBe(false);
+    });
+
+    test('returns false when no comments exist', () => {
+      expect(hasJson5Comments('{\n  name: "test"\n}')).toBe(false);
+    });
   });
 
   describe('isFileNotFoundError', () => {

--- a/src/core/__tests__/json5-utils.test.ts
+++ b/src/core/__tests__/json5-utils.test.ts
@@ -108,9 +108,7 @@ describe('json5-utils', () => {
 
   describe('hasJson5Comments', () => {
     test('returns true for line comments', () => {
-      expect(hasJson5Comments('{\n  // comment\n  name: "test"\n}')).toBe(
-        true
-      );
+      expect(hasJson5Comments('{\n  // comment\n  name: "test"\n}')).toBe(true);
     });
 
     test('returns true for block comments', () => {

--- a/src/core/json5-utils.ts
+++ b/src/core/json5-utils.ts
@@ -3,6 +3,8 @@ import JSON5 from 'json5';
 
 import type { ConfigSnapshot } from './types';
 
+type Json5StringDelimiter = '"' | "'";
+
 function ensureObjectRoot(
   parsed: unknown,
   errorMessage: string
@@ -79,6 +81,65 @@ export async function writeJson5(
   // with openclaw gateway which may not handle unquoted keys
   const content = JSON.stringify(data, null, 2);
   await fs.writeFile(filePath, content, 'utf-8');
+}
+
+export function hasJson5Comments(content: string): boolean {
+  let inBlockComment = false;
+  let inLineComment = false;
+  let inString: Json5StringDelimiter | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+    const next = content[i + 1];
+
+    if (inLineComment) {
+      if (char === '\n' || char === '\r') {
+        inLineComment = false;
+      }
+      continue;
+    }
+
+    if (inBlockComment) {
+      if (char === '*' && next === '/') {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (inString !== null) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+
+      if (char === '\\') {
+        escaped = true;
+        continue;
+      }
+
+      if (char === inString) {
+        inString = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      inString = char;
+      continue;
+    }
+
+    if (char === '/' && next === '/') {
+      return true;
+    }
+
+    if (char === '/' && next === '*') {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function parseJson5(content: string): Record<string, unknown> {

--- a/src/core/json5-utils.ts
+++ b/src/core/json5-utils.ts
@@ -3,7 +3,6 @@ import JSON5 from 'json5';
 
 import type { ConfigSnapshot } from './types';
 
-type Json5StringDelimiter = '"' | "'";
 
 function ensureObjectRoot(
   parsed: unknown,
@@ -83,63 +82,21 @@ export async function writeJson5(
   await fs.writeFile(filePath, content, 'utf-8');
 }
 
+/**
+ * Strip JSON5 string literals so comment markers inside strings are ignored.
+ */
+const JSON5_STRING_RE = /"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/g;
+
+function stripJson5Strings(content: string): string {
+  return content.replace(JSON5_STRING_RE, '""');
+}
+
+/**
+ * Detect JSON5 comments (// or /* ... *​/) outside of string literals.
+ */
 export function hasJson5Comments(content: string): boolean {
-  let inBlockComment = false;
-  let inLineComment = false;
-  let inString: Json5StringDelimiter | null = null;
-  let escaped = false;
-
-  for (let i = 0; i < content.length; i++) {
-    const char = content[i];
-    const next = content[i + 1];
-
-    if (inLineComment) {
-      if (char === '\n' || char === '\r') {
-        inLineComment = false;
-      }
-      continue;
-    }
-
-    if (inBlockComment) {
-      if (char === '*' && next === '/') {
-        inBlockComment = false;
-        i++;
-      }
-      continue;
-    }
-
-    if (inString !== null) {
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-
-      if (char === '\\') {
-        escaped = true;
-        continue;
-      }
-
-      if (char === inString) {
-        inString = null;
-      }
-      continue;
-    }
-
-    if (char === '"' || char === "'") {
-      inString = char;
-      continue;
-    }
-
-    if (char === '/' && next === '/') {
-      return true;
-    }
-
-    if (char === '/' && next === '*') {
-      return true;
-    }
-  }
-
-  return false;
+  const stripped = stripJson5Strings(content);
+  return stripped.includes('//') || stripped.includes('/*');
 }
 
 export function parseJson5(content: string): Record<string, unknown> {

--- a/src/core/json5-utils.ts
+++ b/src/core/json5-utils.ts
@@ -3,7 +3,6 @@ import JSON5 from 'json5';
 
 import type { ConfigSnapshot } from './types';
 
-
 function ensureObjectRoot(
   parsed: unknown,
   errorMessage: string


### PR DESCRIPTION
Fixes #9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves apply and dry-run messaging by detecting JSON5 comments and warning clearly when they will be removed or when writing as standard JSON. Fixes #9.

- **Bug Fixes**
  - Detects JSON5 line/block comments outside strings.
  - Dry-run shows a path-specific note when comments will be lost, and when the file will be created as standard JSON.
  - Apply prints path-specific warnings when comments exist or when rewriting to standard JSON.
  - Added tests for apply and json5-utils, including comment detection.

- **Refactors**
  - Centralizes comment-loss messages and simplifies detection by stripping string literals before scanning.

<sup>Written for commit 4ce9ec6ab8a8b4d99b10d7592f2e9e11bf19bfeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

