### PR TITLE
feat(upload): include skills in uploaded preset

### DIFF
--- a/src/commands/__tests__/upload.test.ts
+++ b/src/commands/__tests__/upload.test.ts
@@ -87,6 +87,18 @@ describe('upload: buildManifest', () => {
     expect(manifest.config).toEqual({});
     expect(manifest.workspaceFiles).toEqual([]);
   });
+
+  test('includes skills when provided', () => {
+    const manifest = buildManifest(
+      'skill-preset',
+      {},
+      ['AGENTS.md'],
+      'Skill preset',
+      ['prompt-guard', 'tmux-opencode']
+    );
+
+    expect(manifest.skills).toEqual(['prompt-guard', 'tmux-opencode']);
+  });
 });
 
 describe('upload: buildPushCommand', () => {
@@ -212,6 +224,41 @@ describe('upload: prepareStagingDir', () => {
       );
       expect(content).toContain('AGENTS.md');
       expect(content).toContain('workspaceFiles');
+    } finally {
+      await fs.rm(stagingDir, { recursive: true, force: true });
+    }
+  });
+
+  test('copies skills directory into staging dir', async () => {
+    const skillDir = path.join(tempWorkspaceDir, 'skills', 'my-skill');
+    await fs.mkdir(path.join(skillDir, 'scripts'), { recursive: true });
+    await fs.writeFile(path.join(skillDir, 'SKILL.md'), '# My Skill', 'utf-8');
+    await fs.writeFile(
+      path.join(skillDir, 'scripts', 'run.sh'),
+      '#!/bin/sh\necho "ok"\n',
+      'utf-8'
+    );
+
+    const manifest = buildManifest('test', {}, [], undefined, ['my-skill']);
+    const stagingDir = await prepareStagingDir(
+      manifest,
+      tempWorkspaceDir,
+      [],
+      ['my-skill']
+    );
+
+    try {
+      const entry = await fs.readFile(
+        path.join(stagingDir, 'skills', 'my-skill', 'SKILL.md'),
+        'utf-8'
+      );
+      expect(entry).toBe('# My Skill');
+
+      const script = await fs.readFile(
+        path.join(stagingDir, 'skills', 'my-skill', 'scripts', 'run.sh'),
+        'utf-8'
+      );
+      expect(script).toContain('echo "ok"');
     } finally {
       await fs.rm(stagingDir, { recursive: true, force: true });
     }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -13,7 +13,12 @@ import {
 } from '../core/json5-utils';
 import { filterSensitiveFields } from '../core/sensitive-filter';
 import type { PresetManifest } from '../core/types';
-import { listWorkspaceFiles, resolveWorkspaceDir } from '../core/workspace';
+import {
+  copyWorkspaceSkills,
+  listWorkspaceFiles,
+  listWorkspaceSkills,
+  resolveWorkspaceDir,
+} from '../core/workspace';
 
 interface UploadOptions {
   create?: boolean;
@@ -170,9 +175,10 @@ export function buildManifest(
   repoName: string,
   filteredConfig: Record<string, unknown>,
   workspaceFileList: string[],
-  description?: string
+  description?: string,
+  skills: string[] = []
 ): PresetManifest {
-  return {
+  const manifest: PresetManifest = {
     name: repoName,
     description:
       description ??
@@ -181,12 +187,19 @@ export function buildManifest(
     config: filteredConfig,
     workspaceFiles: workspaceFileList,
   };
+
+  if (skills.length > 0) {
+    manifest.skills = skills;
+  }
+
+  return manifest;
 }
 
 export async function prepareStagingDir(
   manifest: PresetManifest,
   workspaceDir: string,
-  workspaceFileList: string[]
+  workspaceFileList: string[],
+  workspaceSkills: string[] = []
 ): Promise<string> {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'apex-upload-'));
 
@@ -205,6 +218,10 @@ export async function prepareStagingDir(
     const src = path.join(workspaceDir, filename);
     const dest = path.join(tmpDir, filename);
     await fs.copyFile(src, dest);
+  }
+
+  if (workspaceSkills.length > 0) {
+    await copyWorkspaceSkills(workspaceDir, tmpDir, workspaceSkills);
   }
 
   return tmpDir;
@@ -278,10 +295,11 @@ export async function uploadCommand(
 
   // Collect workspace files
   const workspaceFileList = await listWorkspaceFiles(workspaceDir);
-  if (workspaceFileList.length === 0) {
+  const workspaceSkillList = await listWorkspaceSkills(workspaceDir);
+  if (workspaceFileList.length === 0 && workspaceSkillList.length === 0) {
     console.log(
       pc.yellow(
-        '⚠ No workspace files found. The preset will only contain config.'
+        '⚠ No workspace files or skills found. The preset will only contain config.'
       )
     );
   }
@@ -296,7 +314,8 @@ export async function uploadCommand(
     repo,
     filteredConfig,
     workspaceFileList,
-    options.description
+    options.description,
+    workspaceSkillList
   );
 
   // Handle repo creation/existence
@@ -320,11 +339,12 @@ export async function uploadCommand(
     );
   }
 
-  // Prepare staging directory with flat structure
+  // Prepare staging directory with preset payload
   const stagingDir = await prepareStagingDir(
     manifest,
     workspaceDir,
-    workspaceFileList
+    workspaceFileList,
+    workspaceSkillList
   );
 
   try {
@@ -343,6 +363,9 @@ export async function uploadCommand(
   );
   if (workspaceFileList.length > 0) {
     console.log(`  Workspace files: ${workspaceFileList.join(', ')}`);
+  }
+  if (workspaceSkillList.length > 0) {
+    console.log(`  Skills: ${workspaceSkillList.join(', ')}`);
   }
   console.log('  Preset manifest: preset.json5');
   if (filteredKeyCount < configKeyCount) {


### PR DESCRIPTION
Fixes #10

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds skill support to uploads. Presets now include a skills list in preset.json5 and bundle the selected skills’ files.

- **New Features**
  - Add skills to the preset manifest when present.
  - Detect workspace skills and copy their directories into the staging payload.
  - Warn when no workspace files or skills are found; log included skills.
  - Tests cover manifest skills and staging copy behavior.

<sup>Written for commit 801d06f0c083e05b8177f7e86e82baf145070d05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

