### PR TITLE
fix: validate preset names to prevent path traversal

### DIFF
--- a/src/commands/__tests__/apply.test.ts
+++ b/src/commands/__tests__/apply.test.ts
@@ -584,6 +584,15 @@ describe('applyCommand', () => {
       ).theme
     ).toBe('all-in-one power assistant');
   });
+
+  test('rejects invalid local preset names', async () => {
+    const invalidNames = ['', 'bad$name', 'bad name', 'bad\\name'];
+    for (const name of invalidNames) {
+      await expect(applyCommand(name)).rejects.toThrow(
+        `Invalid preset name '${name}'. Only letters, numbers, '_' and '-' are allowed.`
+      );
+    }
+  });
 });
 
 describe('remote apply', () => {

--- a/src/commands/__tests__/export.test.ts
+++ b/src/commands/__tests__/export.test.ts
@@ -101,6 +101,15 @@ describe('exportCommand', () => {
     );
   });
 
+  test('rejects invalid preset names', async () => {
+    const invalidNames = ['', 'bad$name', 'bad name', 'bad/name', '../bad'];
+    for (const name of invalidNames) {
+      await expect(exportCommand(name)).rejects.toThrow(
+        `Invalid preset name '${name}'. Only letters, numbers, '_' and '-' are allowed.`
+      );
+    }
+  });
+
   test('--force overwrites existing preset', async () => {
     await exportCommand('force-test');
 

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -15,6 +15,7 @@ import {
 } from '../core/json5-utils';
 import { migrateLegacyKeys } from '../core/legacy-migration';
 import { deepMerge } from '../core/merge';
+import { assertValidPresetName } from '../core/preset-name';
 import { loadPreset } from '../core/preset-loader';
 import { cloneToCache, isGitHubRef, parseGitHubRef } from '../core/remote';
 import { filterSensitiveFields } from '../core/sensitive-filter';
@@ -68,6 +69,8 @@ async function resolvePreset(
       presetDir: cachePath,
     };
   }
+
+  assertValidPresetName(presetName);
 
   const userPresetPath = path.join(presetsDir, presetName);
   let userPreset: ResolvedPreset | null = null;

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -15,8 +15,8 @@ import {
 } from '../core/json5-utils';
 import { migrateLegacyKeys } from '../core/legacy-migration';
 import { deepMerge } from '../core/merge';
-import { assertValidPresetName } from '../core/preset-name';
 import { loadPreset } from '../core/preset-loader';
+import { assertValidPresetName } from '../core/preset-name';
 import { cloneToCache, isGitHubRef, parseGitHubRef } from '../core/remote';
 import { filterSensitiveFields } from '../core/sensitive-filter';
 import { copySkills } from '../core/skills';

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -4,6 +4,7 @@ import pc from 'picocolors';
 
 import { resolveOpenClawPaths } from '../core/config-path';
 import { isFileNotFoundError, readJson5 } from '../core/json5-utils';
+import { assertValidPresetName } from '../core/preset-name';
 import { savePreset } from '../core/preset-loader';
 import { filterSensitiveFields } from '../core/sensitive-filter';
 import type { PresetManifest } from '../core/types';
@@ -19,6 +20,7 @@ export async function exportCommand(
   name: string,
   options: ExportOptions = {}
 ): Promise<void> {
+  assertValidPresetName(name);
   const paths = await resolveOpenClawPaths();
 
   // Check if preset already exists

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -4,8 +4,8 @@ import pc from 'picocolors';
 
 import { resolveOpenClawPaths } from '../core/config-path';
 import { isFileNotFoundError, readJson5 } from '../core/json5-utils';
-import { assertValidPresetName } from '../core/preset-name';
 import { savePreset } from '../core/preset-loader';
+import { assertValidPresetName } from '../core/preset-name';
 import { filterSensitiveFields } from '../core/sensitive-filter';
 import type { PresetManifest } from '../core/types';
 import { exportWorkspaceFiles, resolveWorkspaceDir } from '../core/workspace';

--- a/src/core/__tests__/preset-name.test.ts
+++ b/src/core/__tests__/preset-name.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+
+import { assertValidPresetName, isValidPresetName } from '../preset-name';
+
+describe('preset name validation', () => {
+  test('accepts names with letters, numbers, underscores, and hyphens', () => {
+    expect(isValidPresetName('apex')).toBe(true);
+    expect(isValidPresetName('apex_2')).toBe(true);
+    expect(isValidPresetName('apex-2')).toBe(true);
+    expect(isValidPresetName('Apex_2026')).toBe(true);
+  });
+
+  test('rejects empty names and names with invalid characters', () => {
+    expect(isValidPresetName('')).toBe(false);
+    expect(isValidPresetName('bad$name')).toBe(false);
+    expect(isValidPresetName('bad name')).toBe(false);
+    expect(isValidPresetName('bad/name')).toBe(false);
+    expect(isValidPresetName('../bad')).toBe(false);
+  });
+
+  test('throws an actionable error for invalid names', () => {
+    expect(() => assertValidPresetName('bad/name')).toThrow(
+      "Invalid preset name 'bad/name'. Only letters, numbers, '_' and '-' are allowed."
+    );
+  });
+});

--- a/src/core/preset-name.ts
+++ b/src/core/preset-name.ts
@@ -1,0 +1,13 @@
+const PRESET_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function isValidPresetName(name: string): boolean {
+  return PRESET_NAME_PATTERN.test(name);
+}
+
+export function assertValidPresetName(name: string): void {
+  if (!isValidPresetName(name)) {
+    throw new Error(
+      `Invalid preset name '${name}'. Only letters, numbers, '_' and '-' are allowed.`
+    );
+  }
+}


### PR DESCRIPTION
Fixes #12

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate preset names to prevent path traversal and invalid input in apply and export. Only letters, numbers, '_' and '-' are allowed; invalid names now return a clear error.

- **Bug Fixes**
  - Added central validator (isValidPresetName/assertValidPresetName), wired into apply/export; fixed Biome lint.
  - Added unit tests for allowed chars and invalid cases (empty, spaces, special chars, slashes, dot segments).

<sup>Written for commit 0618e4ab7d4a45110117c9f7e06f26d03fb40b81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

