### PR TITLE
feat(diff): support remote preset references

### DIFF
--- a/src/commands/__tests__/diff.test.ts
+++ b/src/commands/__tests__/diff.test.ts
@@ -197,9 +197,53 @@ describe('diffCommand', () => {
     process.env.OPENCLAW_CONFIG_PATH = configPath;
 
     await expect(diffCommand('nonexistent-preset-xyz')).rejects.toThrow(
-      "Preset 'nonexistent-preset-xyz' not found."
+      "Preset 'nonexistent-preset-xyz' not found. Run 'apex list' to see available presets."
     );
   });
+
+  test('supports remote preset references in owner/repo format', async () => {
+    const configPath = path.join(tempStateDir, 'openclaw.json');
+    await fs.writeFile(configPath, '{}', 'utf-8');
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+    const cachePath = path.join(
+      tempStateDir,
+      'apex',
+      'presets',
+      'minpeter--demo-researcher'
+    );
+    await fs.mkdir(cachePath, { recursive: true });
+    await fs.writeFile(
+      path.join(cachePath, 'preset.json5'),
+      JSON.stringify({
+        name: 'demo-researcher',
+        description: 'Cached remote preset for diff test',
+        version: '1.0.0',
+        config: {
+          identity: { name: 'RemoteBot' },
+        },
+      }),
+      'utf-8'
+    );
+
+    await diffCommand('minpeter/demo-researcher', { json: true });
+
+    const jsonOutput = output.at(-1);
+    expect(jsonOutput).toBeDefined();
+    const parsed = JSON.parse(jsonOutput as string) as {
+      preset: string;
+      changes: { path: string; type: string }[];
+      workspaceFiles: { toAdd: string[]; toReplace: string[] };
+    };
+
+    expect(parsed.preset).toBe('minpeter/demo-researcher');
+    expect(Array.isArray(parsed.changes)).toBe(true);
+    expect(typeof parsed.workspaceFiles).toBe('object');
+    expect(Array.isArray(parsed.workspaceFiles.toAdd)).toBe(true);
+    expect(Array.isArray(parsed.workspaceFiles.toReplace)).toBe(true);
+
+    await expect(fs.stat(cachePath)).resolves.toBeDefined();
+  }, 60_000);
 
   test('throws on invalid current config JSON5', async () => {
     const configPath = path.join(tempStateDir, 'openclaw.json');

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -4,6 +4,7 @@ import { resolveOpenClawPaths } from '../core/config-path';
 import { isFileNotFoundError, readJson5 } from '../core/json5-utils';
 import { migrateLegacyKeys } from '../core/legacy-migration';
 import { loadPreset } from '../core/preset-loader';
+import { cloneToCache, isGitHubRef, parseGitHubRef } from '../core/remote';
 import { filterSensitiveFields } from '../core/sensitive-filter';
 import type { PresetManifest } from '../core/types';
 import { listWorkspaceFiles, resolveWorkspaceDir } from '../core/workspace';
@@ -30,6 +31,13 @@ async function resolvePresetForDiff(
   presetName: string,
   presetsDir: string
 ): Promise<PresetManifest> {
+  if (isGitHubRef(presetName)) {
+    const { owner, repo } = parseGitHubRef(presetName);
+    const cachePath = await cloneToCache(owner, repo, presetsDir);
+    console.log(pc.green(`Remote preset '${owner}/${repo}' ready.`));
+    return await loadPreset(cachePath);
+  }
+
   const userPresetPath = path.join(presetsDir, presetName);
   try {
     return await loadPreset(userPresetPath);
@@ -43,7 +51,9 @@ async function resolvePresetForDiff(
     (p) => p.name === presetName
   );
   if (!builtin) {
-    throw new Error(`Preset '${presetName}' not found.`);
+    throw new Error(
+      `Preset '${presetName}' not found. Run 'apex list' to see available presets.`
+    );
   }
 
   return builtin;


### PR DESCRIPTION
Fixes #13

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for remote preset references in owner/repo format for the diff command. The command clones the preset to a local cache and loads it automatically.

- **New Features**
  - Recognizes GitHub-style refs (owner/repo) and clones to cache before diff.
  - Improves missing preset error with "Run 'apex list'..." guidance.
  - Adds tests for remote refs, JSON output, and cache creation.

<sup>Written for commit a71134662f2bb13379a6f758d6bc5868c2b1f18f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

