### PR TITLE
fix(remote): preserve git clone error details

### DIFF
--- a/src/core/__tests__/remote.test.ts
+++ b/src/core/__tests__/remote.test.ts
@@ -9,6 +9,8 @@ const tempDirs: string[] = [];
 const INVALID_GITHUB_REFERENCE_PATTERN = /Invalid GitHub reference/;
 const INVALID_GITHUB_OWNER_REPO_PATTERN = /Invalid GitHub owner\/repo/;
 const FAILED_TO_CLONE_PATTERN = /Failed to clone/;
+const FAILED_TO_CLONE_DETAILS_PATTERN = /Details:/;
+const FAILED_TO_CLONE_GIT_FATAL_PATTERN = /fatal:/i;
 
 afterEach(async () => {
   await Promise.all(
@@ -201,12 +203,13 @@ describe('cloneToCache', () => {
 
   test('throws on non-existent repository', async () => {
     const presetsDir = await makeTempPresetsDir();
-    await expect(
-      cloneToCache(
-        'nonexistent-owner-xyz-abc',
-        'nonexistent-repo-xyz-abc',
-        presetsDir
-      )
-    ).rejects.toThrow(FAILED_TO_CLONE_PATTERN);
+    const clonePromise = cloneToCache(
+      'nonexistent-owner-xyz-abc',
+      'nonexistent-repo-xyz-abc',
+      presetsDir
+    );
+    await expect(clonePromise).rejects.toThrow(FAILED_TO_CLONE_PATTERN);
+    await expect(clonePromise).rejects.toThrow(FAILED_TO_CLONE_DETAILS_PATTERN);
+    await expect(clonePromise).rejects.toThrow(FAILED_TO_CLONE_GIT_FATAL_PATTERN);
   }, 60_000);
 });

--- a/src/core/__tests__/remote.test.ts
+++ b/src/core/__tests__/remote.test.ts
@@ -210,6 +210,8 @@ describe('cloneToCache', () => {
     );
     await expect(clonePromise).rejects.toThrow(FAILED_TO_CLONE_PATTERN);
     await expect(clonePromise).rejects.toThrow(FAILED_TO_CLONE_DETAILS_PATTERN);
-    await expect(clonePromise).rejects.toThrow(FAILED_TO_CLONE_GIT_FATAL_PATTERN);
+    await expect(clonePromise).rejects.toThrow(
+      FAILED_TO_CLONE_GIT_FATAL_PATTERN
+    );
   }, 60_000);
 });

--- a/src/core/remote.ts
+++ b/src/core/remote.ts
@@ -36,6 +36,43 @@ function isPathTraversalAttempt(input: string): boolean {
   return input === '..' || input.startsWith('../') || input.includes('/../');
 }
 
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value === 'string') {
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+  if (value instanceof Uint8Array) {
+    const normalized = new TextDecoder().decode(value).trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+  return null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'stderr' in error) {
+    const stderrText = toNonEmptyString(error.stderr);
+    if (stderrText) {
+      return stderrText;
+    }
+  }
+  if (error instanceof Error) {
+    const messageText = toNonEmptyString(error.message);
+    if (messageText) {
+      return messageText;
+    }
+  }
+
+  const stringText = toNonEmptyString(error);
+  if (stringText) {
+    return stringText;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
 export function isGitHubRef(input: string): boolean {
   if (!input) {
     return false;
@@ -140,9 +177,13 @@ export async function cloneToCache(
     await fs.rm(cachePath, { recursive: true, force: true });
     await fs.rename(tmpDir, cachePath);
     return cachePath;
-  } catch {
+  } catch (error: unknown) {
+    const errorMessage = getErrorMessage(error);
     throw new Error(
-      `Failed to clone '${owner}/${repo}'. Ensure the repository exists and is public.`
+      `Failed to clone '${owner}/${repo}'. Ensure the repository exists and is public. Details: ${errorMessage}`,
+      {
+        cause: error,
+      }
     );
   } finally {
     await fs


### PR DESCRIPTION
Fixes #14

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves git clone error details in cloneToCache so failures include git stderr. Addresses #14 and updates tests to assert detailed messages.

- **Bug Fixes**
  - Extracts stderr/message via getErrorMessage and adds them to the error with "Details:"; sets the original error as cause.
  - Updates tests to expect "Details:" and "fatal:" for non-existent repos; fixes Biome lint.

<sup>Written for commit 1d11b2d3a89a81f093dfe8116c7acaecc8da6b4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

