### PR TITLE
feat: add --verbose flag for detailed logging

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ program
   .description('Apply a preset to your OpenClaw configuration')
   .argument('<preset>', 'Preset name to apply')
   .option('--dry-run', 'Show what would change without applying')
+  .option('--verbose', 'Enable detailed operation logging')
   .option('--no-backup', 'Skip creating a backup (use with caution)')
   .option(
     '--clean',
@@ -54,6 +55,7 @@ program
       preset: string,
       options: {
         dryRun?: boolean;
+        verbose?: boolean;
         backup?: boolean;
         clean?: boolean;
         force?: boolean;
@@ -62,6 +64,7 @@ program
       try {
         await applyCommand(preset, {
           dryRun: options.dryRun,
+          verbose: options.verbose,
           noBackup: !options.backup,
           clean: options.clean,
           force: options.force,
@@ -81,16 +84,23 @@ program
   .argument('<name>', 'Name for the new preset')
   .option('--description <desc>', 'Preset description')
   .option('--version <ver>', 'Preset version', '1.0.0')
+  .option('--verbose', 'Enable detailed operation logging')
   .option('--force', 'Overwrite existing preset')
   .action(
     async (
       name: string,
-      options: { description?: string; version: string; force?: boolean }
+      options: {
+        description?: string;
+        version: string;
+        verbose?: boolean;
+        force?: boolean;
+      }
     ) => {
       try {
         await exportCommand(name, {
           description: options.description,
           version: options.version,
+          verbose: options.verbose,
           force: options.force,
         });
       } catch (err) {
@@ -107,21 +117,28 @@ program
   .description('Show diff between current config and a preset')
   .argument('<preset>', 'Preset name to compare against')
   .option('--json', 'Output as JSON')
-  .action(async (preset: string, options: { json?: boolean }) => {
-    try {
-      await diffCommand(preset, { json: options.json });
-    } catch (err) {
-      console.error(
-        `Error: ${err instanceof Error ? err.message : String(err)}`
-      );
-      process.exit(1);
+  .option('--verbose', 'Enable detailed operation logging')
+  .action(
+    async (preset: string, options: { json?: boolean; verbose?: boolean }) => {
+      try {
+        await diffCommand(preset, {
+          json: options.json,
+          verbose: options.verbose,
+        });
+      } catch (err) {
+        console.error(
+          `Error: ${err instanceof Error ? err.message : String(err)}`
+        );
+        process.exit(1);
+      }
     }
-  });
+  );
 
 program
   .command('install')
   .description('Install the apex preset (shortcut for: apply apex)')
   .option('--dry-run', 'Show what would change without applying')
+  .option('--verbose', 'Enable detailed operation logging')
   .option('--no-backup', 'Skip creating a backup (use with caution)')
   .option(
     '--clean',
@@ -130,12 +147,14 @@ program
   .action(
     async (options: {
       dryRun?: boolean;
+      verbose?: boolean;
       backup?: boolean;
       clean?: boolean;
     }) => {
       try {
         await applyCommand('apex', {
           dryRun: options.dryRun,
+          verbose: options.verbose,
           noBackup: !options.backup,
           clean: options.clean,
         });

--- a/src/commands/__tests__/apply.test.ts
+++ b/src/commands/__tests__/apply.test.ts
@@ -295,6 +295,29 @@ describe('applyCommand', () => {
     expect(combined).toContain('removes those comments');
   });
 
+  test('--verbose prints detailed operation logs', async () => {
+    const env = await createTempEnv('openclaw-apply-verbose-');
+
+    await writeConfig(env.configPath, { identity: { name: 'VerboseBase' } });
+    await writeUserPreset(env.presetsDir, 'verbose-preset', {
+      name: 'verbose-preset',
+      description: 'Verbose apply test',
+      version: '1.0.0',
+      config: {
+        identity: { name: 'VerboseUpdated' },
+      },
+    });
+
+    const logs = await captureLogs(async () => {
+      await applyCommand('verbose-preset', { noBackup: true, verbose: true });
+    });
+
+    const combined = logs.join('\n');
+    expect(combined).toContain('[verbose]');
+    expect(combined).toContain('Resolved paths:');
+    expect(combined).toContain('Apply flow completed');
+  });
+
   test('filters sensitive fields from preset config before merge', async () => {
     const env = await createTempEnv('openclaw-apply-sensitive-');
 

--- a/src/commands/__tests__/diff.test.ts
+++ b/src/commands/__tests__/diff.test.ts
@@ -71,6 +71,19 @@ describe('diffCommand', () => {
     expect(combined).toContain('Apex');
   });
 
+  test('--verbose prints detailed operation logs', async () => {
+    const configPath = path.join(tempStateDir, 'openclaw.json');
+    await fs.writeFile(configPath, '{}', 'utf-8');
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+    await diffCommand('apex', { verbose: true });
+
+    const combined = output.join('\n');
+    expect(combined).toContain('[verbose]');
+    expect(combined).toContain('Resolved paths:');
+    expect(combined).toContain('Computed config diff');
+  });
+
   test('shows removed keys (null) in red with - prefix', async () => {
     // Create a custom preset with null value (meaning delete)
     const presetsDir = path.join(
@@ -138,6 +151,27 @@ describe('diffCommand', () => {
     const listChange = parsed.changes.find((c) => c.path === 'agents.list');
     expect(listChange).toBeDefined();
     expect(listChange?.type).toBe('changed');
+  });
+
+  test('--verbose with --json still emits parseable JSON on stdout', async () => {
+    const configPath = path.join(tempStateDir, 'openclaw.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({ identity: { name: 'OldBot' } }),
+      'utf-8'
+    );
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+
+    await diffCommand('apex', { json: true, verbose: true });
+
+    const jsonOutput = output.join('\n');
+    const parsed = JSON.parse(jsonOutput) as {
+      changes: { path: string; type: string }[];
+      preset: string;
+    };
+
+    expect(parsed.preset).toBe('apex');
+    expect(Array.isArray(parsed.changes)).toBe(true);
   });
 
   test('reports workspace file differences', async () => {

--- a/src/commands/__tests__/export.test.ts
+++ b/src/commands/__tests__/export.test.ts
@@ -189,6 +189,15 @@ describe('exportCommand', () => {
     expect(combined).toContain('exported');
   });
 
+  test('--verbose prints detailed operation logs', async () => {
+    await exportCommand('verbose-summary-test', { verbose: true });
+
+    const combined = output.join('\n');
+    expect(combined).toContain('[verbose]');
+    expect(combined).toContain('Resolved paths:');
+    expect(combined).toContain('Writing preset manifest');
+  });
+
   test('prints workspace files in summary when files are copied', async () => {
     const workspaceDir = path.join(tempStateDir, 'workspace');
     await fs.mkdir(workspaceDir, { recursive: true });

--- a/src/commands/apply.ts
+++ b/src/commands/apply.ts
@@ -34,6 +34,7 @@ interface ApplyOptions {
   dryRun?: boolean;
   force?: boolean;
   noBackup?: boolean;
+  verbose?: boolean;
 }
 
 interface ResolvedPreset {
@@ -54,6 +55,33 @@ function resolveBuiltinPresetDir(presetName: string): string {
 
 function hasPresetConfig(preset: PresetManifest): boolean {
   return Boolean(preset.config && Object.keys(preset.config).length > 0);
+}
+
+function logVerbose(enabled: boolean, message: string): void {
+  if (!enabled) {
+    return;
+  }
+
+  console.log(pc.dim(`[verbose] ${message}`));
+}
+
+function getBackupMode(noBackup: boolean | undefined): string {
+  if (noBackup) {
+    return 'disabled';
+  }
+
+  return 'enabled';
+}
+
+function describeConfigStatus(
+  configExists: boolean,
+  configPath: string
+): string {
+  if (configExists) {
+    return `Current config found at ${configPath}`;
+  }
+
+  return `Current config not found at ${configPath}`;
 }
 
 async function resolvePreset(
@@ -349,20 +377,34 @@ export async function applyCommand(
   presetName: string,
   options: ApplyOptions = {}
 ): Promise<void> {
+  const verbose = Boolean(options.verbose);
   const paths = await resolveOpenClawPaths();
+  logVerbose(
+    verbose,
+    `Resolved paths: config=${paths.configPath}, presets=${paths.presetsDir}, backups=${paths.backupsDir}, state=${paths.stateDir}`
+  );
+
+  logVerbose(verbose, `Resolving preset '${presetName}'`);
   const { preset, presetDir } = await resolvePreset(
     presetName,
     paths.presetsDir,
     options.force
   );
+  logVerbose(verbose, `Loaded preset '${preset.name}' from ${presetDir}`);
 
   const configSnapshot = await loadCurrentConfig(paths.configPath);
   let currentConfig = configSnapshot.config;
   let configExists = configSnapshot.exists;
   const configHasJson5Comments = configSnapshot.hasJson5Comments;
   const workspaceDir = resolveWorkspaceDir(currentConfig, paths.stateDir);
+  logVerbose(verbose, describeConfigStatus(configExists, paths.configPath));
+  logVerbose(verbose, `Workspace directory resolved to ${workspaceDir}`);
 
   if (options.clean && !options.dryRun) {
+    logVerbose(
+      verbose,
+      `Running clean mode with backup ${getBackupMode(options.noBackup)}`
+    );
     await runCleanMode(
       workspaceDir,
       paths.configPath,
@@ -373,6 +415,7 @@ export async function applyCommand(
 
     currentConfig = {};
     configExists = false;
+    logVerbose(verbose, 'Clean mode completed');
     console.log(
       pc.yellow('Clean install: existing config and workspace files removed.')
     );
@@ -381,6 +424,10 @@ export async function applyCommand(
   const { applied, mergedConfig, preserved } = buildMergedConfig(
     currentConfig,
     preset
+  );
+  logVerbose(
+    verbose,
+    `Merge complete: ${Object.keys(mergedConfig).length} top-level keys`
   );
   if (applied.length > 0) {
     console.log(pc.dim(`Legacy key migration: ${applied.join(', ')}`));
@@ -392,6 +439,7 @@ export async function applyCommand(
   }
 
   if (options.dryRun) {
+    logVerbose(verbose, 'Dry-run requested; skipping backup and write steps');
     if (options.clean) {
       console.log(pc.yellow('Mode: CLEAN INSTALL'));
     }
@@ -404,6 +452,10 @@ export async function applyCommand(
   }
 
   if (!options.clean) {
+    logVerbose(
+      verbose,
+      `Running regular backup mode with backup ${getBackupMode(options.noBackup)}`
+    );
     await runRegularBackupMode(
       workspaceDir,
       paths.configPath,
@@ -415,6 +467,7 @@ export async function applyCommand(
   }
 
   if (hasPresetConfig(preset)) {
+    logVerbose(verbose, `Writing merged config to ${paths.configPath}`);
     if (configExists) {
       console.log(
         pc.yellow(
@@ -437,6 +490,10 @@ export async function applyCommand(
   }
 
   if (preset.workspaceFiles?.length) {
+    logVerbose(
+      verbose,
+      `Copying ${preset.workspaceFiles.length} workspace file(s) from ${presetDir} to ${workspaceDir}`
+    );
     await copyWorkspaceFiles(presetDir, workspaceDir, preset.workspaceFiles);
     console.log(
       pc.green(`OK Workspace files copied: ${preset.workspaceFiles.join(', ')}`)
@@ -444,6 +501,10 @@ export async function applyCommand(
   }
 
   if (preset.skills?.length) {
+    logVerbose(
+      verbose,
+      `Installing ${preset.skills.length} skill(s) from ${path.join(presetDir, 'skills')}`
+    );
     const installed = await copySkills(presetDir, preset.skills, {
       force: options.force,
     });
@@ -453,9 +514,11 @@ export async function applyCommand(
   }
 
   if (process.platform === 'darwin') {
+    logVerbose(verbose, 'Checking Node PATH fix for macOS');
     await fixNodePathIfNeeded();
   }
 
+  logVerbose(verbose, `Apply flow completed for preset '${preset.name}'`);
   console.log(pc.green(`\nOK Preset '${preset.name}' applied.`));
   console.log(
     pc.bold(pc.yellow("Run 'openclaw gateway restart' to activate changes."))

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -12,6 +12,7 @@ import { getBuiltinPresets } from '../presets/index';
 
 interface DiffOptions {
   json?: boolean;
+  verbose?: boolean;
 }
 
 interface DiffEntry {
@@ -19,6 +20,24 @@ interface DiffEntry {
   path: string;
   presetValue?: unknown;
   type: 'added' | 'changed' | 'removed';
+}
+
+function logVerbose(
+  enabled: boolean,
+  message: string,
+  options: { jsonOutput: boolean }
+): void {
+  if (!enabled) {
+    return;
+  }
+
+  const text = pc.dim(`[verbose] ${message}`);
+  if (options.jsonOutput) {
+    console.error(text);
+    return;
+  }
+
+  console.log(text);
 }
 
 function isPresetNotFoundError(error: unknown): boolean {
@@ -142,9 +161,19 @@ export async function diffCommand(
   presetName: string,
   options: DiffOptions = {}
 ): Promise<void> {
-  const paths = await resolveOpenClawPaths();
+  const verbose = Boolean(options.verbose);
+  const jsonOutput = Boolean(options.json);
 
+  const paths = await resolveOpenClawPaths();
+  logVerbose(
+    verbose,
+    `Resolved paths: config=${paths.configPath}, presets=${paths.presetsDir}, state=${paths.stateDir}`,
+    { jsonOutput }
+  );
+
+  logVerbose(verbose, `Resolving preset '${presetName}'`, { jsonOutput });
   const preset = await resolvePresetForDiff(presetName, paths.presetsDir);
+  logVerbose(verbose, `Loaded preset '${preset.name}'`, { jsonOutput });
   const currentConfig = await loadCurrentConfigForDiff(paths.configPath);
 
   const rawPresetConfig = (preset.config ?? {}) as Record<string, unknown>;
@@ -155,14 +184,27 @@ export async function diffCommand(
     filteredCurrentConfig
   );
   const configDiff = computeDiff(normalizedCurrent, presetConfig);
+  logVerbose(
+    verbose,
+    `Computed config diff with ${configDiff.length} change(s)`,
+    { jsonOutput }
+  );
 
   // Workspace diff
   const workspaceDir = resolveWorkspaceDir(currentConfig, paths.stateDir);
+  logVerbose(verbose, `Workspace directory resolved to ${workspaceDir}`, {
+    jsonOutput,
+  });
   const currentWsFiles = await listWorkspaceFiles(workspaceDir);
   const presetWsFiles = preset.workspaceFiles ?? [];
   const wsFilesToAdd = presetWsFiles.filter((f) => !currentWsFiles.includes(f));
   const wsFilesToReplace = presetWsFiles.filter((f) =>
     currentWsFiles.includes(f)
+  );
+  logVerbose(
+    verbose,
+    `Workspace diff: add=${wsFilesToAdd.length}, replace=${wsFilesToReplace.length}`,
+    { jsonOutput }
   );
 
   if (options.json) {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -13,7 +13,16 @@ import { exportWorkspaceFiles, resolveWorkspaceDir } from '../core/workspace';
 interface ExportOptions {
   description?: string;
   force?: boolean;
+  verbose?: boolean;
   version?: string;
+}
+
+function logVerbose(enabled: boolean, message: string): void {
+  if (!enabled) {
+    return;
+  }
+
+  console.log(pc.dim(`[verbose] ${message}`));
 }
 
 export async function exportCommand(
@@ -21,10 +30,16 @@ export async function exportCommand(
   options: ExportOptions = {}
 ): Promise<void> {
   assertValidPresetName(name);
+  const verbose = Boolean(options.verbose);
   const paths = await resolveOpenClawPaths();
+  logVerbose(
+    verbose,
+    `Resolved paths: config=${paths.configPath}, presets=${paths.presetsDir}, state=${paths.stateDir}`
+  );
 
   // Check if preset already exists
   const presetDir = path.join(paths.presetsDir, name);
+  logVerbose(verbose, `Checking if preset directory exists: ${presetDir}`);
   try {
     await fs.access(presetDir);
     if (!options.force) {
@@ -42,6 +57,7 @@ export async function exportCommand(
   // Read current config
   let currentConfig: Record<string, unknown> = {};
   try {
+    logVerbose(verbose, `Reading config from ${paths.configPath}`);
     const snapshot = await readJson5(paths.configPath);
     currentConfig = snapshot.parsed;
   } catch (err) {
@@ -56,9 +72,14 @@ export async function exportCommand(
 
   // Filter sensitive fields
   const filteredConfig = filterSensitiveFields(currentConfig);
+  logVerbose(
+    verbose,
+    `Filtered config keys: before=${Object.keys(currentConfig).length}, after=${Object.keys(filteredConfig).length}`
+  );
 
   // Resolve workspace dir
   const workspaceDir = resolveWorkspaceDir(currentConfig, paths.stateDir);
+  logVerbose(verbose, `Workspace directory resolved to ${workspaceDir}`);
 
   // Build manifest
   const manifest: PresetManifest = {
@@ -71,12 +92,19 @@ export async function exportCommand(
     workspaceFiles: [],
   };
 
+  logVerbose(verbose, `Ensuring preset directory exists: ${presetDir}`);
   await fs.mkdir(presetDir, { recursive: true });
 
   // Copy workspace MD files
+  logVerbose(verbose, `Exporting workspace files from ${workspaceDir}`);
   const copiedFiles = await exportWorkspaceFiles(workspaceDir, presetDir);
   manifest.workspaceFiles = copiedFiles;
+  logVerbose(verbose, `Copied ${copiedFiles.length} workspace file(s)`);
 
+  logVerbose(
+    verbose,
+    `Writing preset manifest to ${path.join(presetDir, 'preset.json5')}`
+  );
   await savePreset(presetDir, manifest);
 
   console.log(pc.green(`\n✓ Preset '${name}' exported to: ${presetDir}`));


### PR DESCRIPTION
Fixes #15

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a --verbose flag to apply, diff, export, and install commands for detailed logging. Keeps stdout as valid JSON when using --json. Fixes #15.

- **New Features**
  - CLI options: --verbose added to apply, diff, export, and install.
  - Detailed logs: path resolution, preset loading, merge/diff counts, workspace actions, backup mode, macOS PATH check, and export manifest steps.
  - Diff: when --json is used, verbose logs go to stderr to keep stdout parseable.
  - Tests: added coverage for verbose logging and JSON parseability.

<sup>Written for commit ed205023b1e9f1803ebc49e5acb3426ecd3da7d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

