### PR TITLE
fix(merge): detect circular references in deepMerge

### DIFF
--- a/src/core/__tests__/merge.test.ts
+++ b/src/core/__tests__/merge.test.ts
@@ -181,4 +181,24 @@ describe('deepMerge', () => {
 
     expect(result).toEqual({ items: [] });
   });
+
+  test('throws clear error when base contains circular reference', () => {
+    const baseChild: Record<string, unknown> = {};
+    baseChild.self = baseChild;
+    const base = { nested: baseChild };
+
+    expect(() => deepMerge(base, { nested: { self: {} } })).toThrow(
+      'Circular reference detected in deepMerge base at nested.self'
+    );
+  });
+
+  test('throws clear error when override contains circular reference', () => {
+    const overrideChild: Record<string, unknown> = {};
+    overrideChild.self = overrideChild;
+    const override = { nested: overrideChild };
+
+    expect(() => deepMerge({ nested: { self: {} } }, override)).toThrow(
+      'Circular reference detected in deepMerge override at nested.self'
+    );
+  });
 });

--- a/src/core/merge.ts
+++ b/src/core/merge.ts
@@ -6,7 +6,10 @@ function pathToString(path: string[]): string {
   return path.length === 0 ? '<root>' : path.join('.');
 }
 
-function throwCircularReferenceError(side: 'base' | 'override', path: string[]) {
+function throwCircularReferenceError(
+  side: 'base' | 'override',
+  path: string[]
+) {
   throw new Error(
     `Circular reference detected in deepMerge ${side} at ${pathToString(path)}`
   );
@@ -45,7 +48,10 @@ function deepMergeInternal(
     }
 
     if (isPlainObject(overrideVal) && isPlainObject(baseVal)) {
-      result[key] = deepMergeInternal(baseVal, overrideVal, seen, [...path, key]);
+      result[key] = deepMergeInternal(baseVal, overrideVal, seen, [
+        ...path,
+        key,
+      ]);
     } else {
       result[key] = overrideVal;
     }

--- a/src/core/merge.ts
+++ b/src/core/merge.ts
@@ -2,10 +2,33 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-export function deepMerge(
+function pathToString(path: string[]): string {
+  return path.length === 0 ? '<root>' : path.join('.');
+}
+
+function throwCircularReferenceError(side: 'base' | 'override', path: string[]) {
+  throw new Error(
+    `Circular reference detected in deepMerge ${side} at ${pathToString(path)}`
+  );
+}
+
+function deepMergeInternal(
   base: Record<string, unknown>,
-  override: Record<string, unknown>
+  override: Record<string, unknown>,
+  seen: WeakSet<object>,
+  path: string[]
 ): Record<string, unknown> {
+  if (seen.has(base)) {
+    throwCircularReferenceError('base', path);
+  }
+
+  if (seen.has(override)) {
+    throwCircularReferenceError('override', path);
+  }
+
+  seen.add(base);
+  seen.add(override);
+
   const result: Record<string, unknown> = { ...base };
 
   for (const key of Object.keys(override)) {
@@ -22,11 +45,21 @@ export function deepMerge(
     }
 
     if (isPlainObject(overrideVal) && isPlainObject(baseVal)) {
-      result[key] = deepMerge(baseVal, overrideVal);
+      result[key] = deepMergeInternal(baseVal, overrideVal, seen, [...path, key]);
     } else {
       result[key] = overrideVal;
     }
   }
 
+  seen.delete(base);
+  seen.delete(override);
+
   return result;
+}
+
+export function deepMerge(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> {
+  return deepMergeInternal(base, override, new WeakSet<object>(), []);
 }


### PR DESCRIPTION
Fixes #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detect circular references in deepMerge to prevent infinite recursion. Throws clear, path-aware errors for both base and override objects.

- **Bug Fixes**
  - Track visited objects with a WeakSet (added/removed during recursion) to detect cycles.
  - Include dot-path in errors: "Circular reference detected in deepMerge base/override at <path>".
  - Add tests for circular references in both base and override; minor Biome lint fixes.

<sup>Written for commit c1f5b472f278a769f77627b21678fefa4d7f8fa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

