### PR TITLE
fix: warn when workspace files are overwritten

### DIFF
--- a/src/core/__tests__/workspace.test.ts
+++ b/src/core/__tests__/workspace.test.ts
@@ -163,6 +163,41 @@ describe('copyWorkspaceFiles', () => {
       'identity'
     );
   });
+
+  test('warns when existing workspace files are overwritten', async () => {
+    const srcDir = path.join(tempDir, 'src');
+    const destDir = path.join(tempDir, 'dest');
+    const { mkdir } = await import('node:fs/promises');
+    await mkdir(srcDir, { recursive: true });
+    await mkdir(destDir, { recursive: true });
+
+    await writeFile(path.join(srcDir, 'AGENTS.md'), 'new agents');
+    await writeFile(path.join(srcDir, 'SOUL.md'), 'new soul');
+    await writeFile(path.join(destDir, 'AGENTS.md'), 'old agents');
+    await writeFile(path.join(destDir, 'SOUL.md'), 'old soul');
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    };
+
+    try {
+      await copyWorkspaceFiles(srcDir, destDir, ['AGENTS.md', 'SOUL.md']);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warnings).toEqual([
+      'Warning: Overwriting existing workspace files: AGENTS.md, SOUL.md',
+    ]);
+    expect(await readFile(path.join(destDir, 'AGENTS.md'), 'utf8')).toBe(
+      'new agents'
+    );
+    expect(await readFile(path.join(destDir, 'SOUL.md'), 'utf8')).toBe(
+      'new soul'
+    );
+  });
 });
 
 describe('exportWorkspaceFiles', () => {

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -102,6 +102,26 @@ export async function copyWorkspaceFiles(
   files: string[]
 ): Promise<void> {
   await fs.mkdir(destDir, { recursive: true });
+  const overwrittenFiles: string[] = [];
+
+  for (const filename of files) {
+    const dest = path.join(destDir, filename);
+    try {
+      await fs.access(dest);
+      overwrittenFiles.push(filename);
+    } catch (error) {
+      if (!isErrnoCode(error, 'ENOENT')) {
+        throw error;
+      }
+    }
+  }
+
+  if (overwrittenFiles.length > 0) {
+    console.warn(
+      `Warning: Overwriting existing workspace files: ${overwrittenFiles.join(', ')}`
+    );
+  }
+
   for (const filename of files) {
     const src = path.join(srcDir, filename);
     const dest = path.join(destDir, filename);


### PR DESCRIPTION
Fixes #23

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn when copyWorkspaceFiles overwrites existing files in the destination workspace. Shows the filenames in the warning to help prevent accidental overwrites.

- **Bug Fixes**
  - Detect existing files and log a console.warn listing the files to be overwritten.
  - Added tests to verify the warning and ensure overwrites still succeed.

<sup>Written for commit c5a605e38336d5fd116cd21925f0f513c15aca31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

