### PR TITLE
fix: replace structuredClone with safe deep clone

### DIFF
--- a/src/core/__tests__/legacy-migration.test.ts
+++ b/src/core/__tests__/legacy-migration.test.ts
@@ -187,4 +187,30 @@ describe('migrateLegacyKeys', () => {
     expect(agentsList[0]).toEqual({ id: 'main', identity: { name: 'Bot' } });
     expect(agentsList[1]).toEqual({ id: 'valid', model: 'gpt-4' });
   });
+
+  test('handles non-serializable values via clone fallback', () => {
+    const config = {
+      identity: { name: 'Bot' },
+      meta: { version: 1n, onApply: () => 'done' },
+      agents: {
+        defaults: {},
+        list: [{ id: 'main', model: 'gpt-4' }],
+      },
+    };
+
+    const result = migrateLegacyKeys(
+      config as unknown as Record<string, unknown>
+    );
+
+    const migratedAgents = result.config.agents as Record<string, unknown>;
+    const agentsList = migratedAgents.list as Record<string, unknown>[];
+    const meta = result.config.meta as Record<string, unknown>;
+
+    expect(agentsList[0].identity).toEqual({ name: 'Bot' });
+    expect(meta.version).toBe(1n);
+    expect(meta.onApply).toBe(config.meta.onApply);
+    expect((config.agents.list[0] as Record<string, unknown>).identity).toBe(
+      undefined
+    );
+  });
 });

--- a/src/core/legacy-migration.ts
+++ b/src/core/legacy-migration.ts
@@ -14,6 +14,51 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function deepCloneFallback(
+  value: unknown,
+  seen: WeakMap<object, unknown> = new WeakMap()
+): unknown {
+  if (Array.isArray(value)) {
+    if (seen.has(value)) {
+      return seen.get(value);
+    }
+
+    const clone: unknown[] = [];
+    seen.set(value, clone);
+
+    for (const item of value) {
+      clone.push(deepCloneFallback(item, seen));
+    }
+
+    return clone;
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) {
+      return seen.get(value);
+    }
+
+    const clone: Record<string, unknown> = {};
+    seen.set(value, clone);
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      clone[key] = deepCloneFallback(nestedValue, seen);
+    }
+
+    return clone;
+  }
+
+  return value;
+}
+
+function safeDeepClone<T>(value: T): T {
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    return deepCloneFallback(value) as T;
+  }
+}
+
 interface MigrationResult {
   applied: string[];
   config: Record<string, unknown>;
@@ -26,7 +71,7 @@ interface MigrationResult {
 export function migrateLegacyKeys(
   config: Record<string, unknown>
 ): MigrationResult {
-  let result: Record<string, unknown> = structuredClone(config);
+  let result: Record<string, unknown> = safeDeepClone(config);
   const applied: string[] = [];
 
   // identity → agents.list[].identity


### PR DESCRIPTION
Fixes #24

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace structuredClone with a safe deep clone in legacy migration to prevent crashes on non-serializable values and keep the input config unchanged. Preserves BigInt and function values during migration. Fixes #24.

- **Bug Fixes**
  - Added safeDeepClone (JSON stringify with deepCloneFallback) to clone configs safely, including circular refs.
  - Updated migrateLegacyKeys to use safeDeepClone instead of structuredClone.
  - Added test covering BigInt, functions, and immutability of the original config.

<sup>Written for commit 4af080a13d47486e9f7b3827b3614c9a98d68d43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

