### PR TITLE
fix(cli): point package bin to src entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,14 +6,13 @@
 
 ## OVERVIEW
 
-Bun + TypeScript CLI for OpenClaw preset lifecycle management: list, apply/install, diff, export, restore, upload. Runtime entry is `src/cli.ts` via launcher `bin/apex.js`; optional compiled artifact is `dist/apex` from `bun run build:compile`.
+Bun + TypeScript CLI for OpenClaw preset lifecycle management: list, apply/install, diff, export, restore, upload. Runtime entry is `src/cli.ts`; optional compiled artifact is `dist/apex` from `bun run build:compile`.
 
 ## STRUCTURE
 
 ```
 apex/
 ├── AGENTS.md                    # root map + cross-module invariants
-├── bin/apex.js                  # launcher; imports src/cli.ts
 ├── src/
 │   ├── cli.ts                   # Commander wiring for all commands
 │   ├── commands/
@@ -86,7 +85,7 @@ apex/
 
 - `install` is intentionally implemented as `apply apex` in CLI wiring.
 - `--dry-run` avoids final writes but can still resolve remote presets/cache.
-- Launcher executes source (`bin/apex.js` -> `src/cli.ts`); compiled binary is a separate path.
+- Launcher executes source from `src/cli.ts`; compiled binary is a separate path.
 - Release workflow runs on `push` to `main`; code-quality runs on both `pull_request` and `push` to `main`.
 
 ## COMMANDS

--- a/bin/apex.js
+++ b/bin/apex.js
@@ -1,2 +1,0 @@
-#!/usr/bin/env bun
-import '../src/cli.ts';

--- a/package.json
+++ b/package.json
@@ -23,10 +23,9 @@
     "bun": ">=1.0.0"
   },
   "bin": {
-    "apex": "bin/apex.js"
+    "apex": "src/cli.ts"
   },
   "files": [
-    "bin/",
     "src/"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Summary
- remove the `bin/apex.js` launcher and use `src/cli.ts` as the package `bin` entry
- remove `bin/` from published files to match the new runtime entrypoint layout
- update `AGENTS.md` references that still documented the deleted launcher path

## Verification
- `bun run check`
- `bun test`
- `bun run build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the package bin from bin/apex.js to src/cli.ts to use the source entry directly and remove the redundant launcher. Dropped bin/ from published files and updated AGENTS.md references; CLI behavior remains unchanged.

<sup>Written for commit f200b616a6bea17b3b510f92b484686aae494464. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

