### PR TITLE
fix(release): generate GitHub release notes with Changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,11 @@ jobs:
       - name: Create Release Pull Request or Publish
         uses: changesets/action@v1
         with:
-          publish: npm publish --provenance --access public
+          publish: bun run release
           version: bun run version
           commit: "chore: version packages"
           title: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Switch Changesets action publish command from direct `npm publish` to `bun run release` so release metadata is handled by `changeset publish`.
- Explicitly enable `createGithubReleases: true` in the release workflow for clearer and reliable GitHub Release note creation.
- Keep OIDC trusted publishing flow tokenless by not adding `NPM_TOKEN` or `NODE_AUTH_TOKEN`.

## Validation
- bun run check
- bun test
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure GitHub Releases and notes are created reliably by letting Changesets handle publishing. Switch the workflow to use bun run release and enable createGithubReleases, while keeping OIDC trusted publishing tokenless.

<sup>Written for commit aa88ae5b2d7b036e205ff3ccd4476cbbe70da362. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

