### PR TITLE
fix(release): enforce OIDC tokenless publish path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -58,4 +57,5 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ""
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `actions/setup-node` so workflow does not inject npm token auth path.
- Explicitly clear `NODE_AUTH_TOKEN` in the Changesets publish step to force npm trusted publishing via OIDC.
- Keep `publish: bun run release` and `createGithubReleases: true` so GitHub releases are still generated from Changesets.

## Root Cause
The Release job environment had `NODE_AUTH_TOKEN` present, and npm publish attempted token auth (`Access token expired or revoked`) instead of pure OIDC trusted publishing.

## Validation
- bun run check
- bun test
- bun run build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces npm trusted publishing via OIDC in the release workflow to prevent token-based auth and publish failures. GitHub Releases from Changesets stay enabled.

- **Bug Fixes**
  - Removed registry-url from actions/setup-node to avoid injecting npm token auth.
  - Cleared NODE_AUTH_TOKEN in the Changesets publish step to force OIDC.

<sup>Written for commit 847f05bf633ecb4f29b9a163c81fbb03a3a3cc66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

